### PR TITLE
Update to Request-Promise v0.3.1

### DIFF
--- a/lib/services/api_factory.js
+++ b/lib/services/api_factory.js
@@ -77,7 +77,7 @@ Api.request = function(opts, headers) {
   }
 
   requestOpts.headers = headers;
-  return request(requestOpts);
+  return request(requestOpts).promise();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "es6-promise": "^1.0.0",
     "lodash": "^2.4.1",
-    "request-promise": "^0.2.0"
+    "request-promise": "^0.3.1"
   },
   "devDependencies": {
     "jest-cli": "^0.1.18"


### PR DESCRIPTION
Hi @chestone 

Out of curiosity I checked your code to see if you are affected by braking changes when upgrading to Request-Promise 0.3.1.

Actually you are. So I added the `.promise()` call to ensure full compatibility. You can find the details in the [migration instructions](https://github.com/tyabonil/request-promise#migrating-from-02x-to-03x).

Cheers,
Nico
